### PR TITLE
Fix copy paste mistake: "Get container" to "Get app" on getApp() function

### DIFF
--- a/tests/TestCase/ContainerTestTrait.php
+++ b/tests/TestCase/ContainerTestTrait.php
@@ -57,7 +57,7 @@ trait ContainerTestTrait
     }
 
     /**
-     * Get container.
+     * Get app.
      *
      * @throws RuntimeException
      *


### PR DESCRIPTION
Fix copy paste mistake: "Get container" to "Get app" on getApp() function