### PR TITLE
Lint PHP files in bin folder

### DIFF
--- a/.cs.php
+++ b/.cs.php
@@ -37,6 +37,7 @@ return PhpCsFixer\Config::create()
         'single_line_throw' => false,
     ])
     ->setFinder(PhpCsFixer\Finder::create()
+        ->in(__DIR__ . '/bin')
         ->in(__DIR__ . '/src')
         ->in(__DIR__ . '/tests')
         ->in(__DIR__ . '/config')

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
         "phinx:create": "phinx create -c config/phinx.php --ansi",
         "phinx:generate": "phinx-migrations generate --overwrite -c config/phinx.php --ansi",
         "phinx:migrate": "phinx migrate -c config/phinx.php --ansi -vvv",
-        "phpstan": "phpstan analyse src tests config --level=max -c phpstan.neon --no-progress --ansi",
+        "phpstan": "phpstan analyse bin src tests config --level=max -c phpstan.neon --no-progress --ansi",
         "schema:dump": "php bin/console.php schema-dump",
         "sniffer:check": "phpcs --standard=phpcs.xml",
         "sniffer:fix": "phpcbf --standard=phpcs.xml",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,6 +3,7 @@
     <arg name="basepath" value="."/>
     <arg name="colors"/>
     <arg value="sp"/>
+    <arg name="extensions" value="php"/>
 
     <config name="ignore_warnings_on_exit" value="1"/>
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,9 +6,11 @@
 
     <config name="ignore_warnings_on_exit" value="1"/>
 
+    <file>./bin</file>
     <file>./src</file>
     <file>./tests</file>
     <file>./config</file>
+    <file>./public/index.php</file>
 
     <rule ref="PSR2"></rule>
     <!-- <rule ref="PSR12"></rule> -->


### PR DESCRIPTION
I've noticed that `bin` folder doesn't exists in most linters configs. I added it to PHP-CS-Fixer, PHP_CodeSniffer and PHPStan configs.

I disabled CSS and JS extensions in PHP_CodeSniffer because I highly doubt that author did that on purpose.

I didn't add `bin` folder to `psalm.xml` because Psalm looks abandoned in current project. It's not even presented in Composer dependencies.

Also have a few suggestions about `bin/deploy.php` script, not related to current PR:
1. I would rewrite all echo lines with `PHP_EOL` constant because that way it should add appropriate linebreak char for every OS. Example:
```diff
---    echo "Check if root: OK\n";
+++    echo 'Check if root: OK' . PHP_EOL;
```
2. I would add suffix `2>&1` to all `system` calls because with that option it returns error text instead of `false` value on failure. Example:
```diff
---    system('sudo vendor/bin/phinx migrate -c config/phinx.php');
+++    system('sudo vendor/bin/phinx migrate -c config/phinx.php 2>&1');
```