### PR TITLE
Exclude dev/unneeded files from dist prod zip archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -37,11 +37,9 @@ docker-compose.yml export-ignore
 .gitignore export-ignore
 .scrutinizer.yml export-ignore
 .travis.yml export-ignore
-.php_cs.dist export-ignore
-phpcs.xml.dist export-ignore
+phpcs.xml export-ignore
 phpstan.neon export-ignore
-phpunit.xml.dist export-ignore
-phoenix.php export-ignore
+phpunit.xml export-ignore
 .editorconfig export-ignore
 build.xml export-ignore
 .sonarcloud.properties export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -27,3 +27,24 @@ docs/* linguist-documentation
 *.ttf binary
 *.woff binary
 *.woff2 binary
+
+# Exclude testing files from distribution
+/.github export-ignore
+/tests export-ignore
+/tmp export-ignore
+CHANGELOG.md export-ignore
+LICENSE export-ignore
+docker-compose.yml export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.scrutinizer.yml export-ignore
+.travis.yml export-ignore
+.php_cs.dist export-ignore
+phpcs.xml.dist export-ignore
+phpstan.neon export-ignore
+phpunit.xml.dist export-ignore
+phoenix.php export-ignore
+.editorconfig export-ignore
+build.xml export-ignore
+.sonarcloud.properties export-ignore
+.cs.php export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -31,7 +31,6 @@ docs/* linguist-documentation
 # Exclude testing files from distribution
 /.github export-ignore
 /tests export-ignore
-CHANGELOG.md export-ignore
 LICENSE export-ignore
 docker-compose.yml export-ignore
 .gitattributes export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -31,7 +31,6 @@ docs/* linguist-documentation
 # Exclude testing files from distribution
 /.github export-ignore
 /tests export-ignore
-/tmp export-ignore
 CHANGELOG.md export-ignore
 LICENSE export-ignore
 docker-compose.yml export-ignore


### PR DESCRIPTION
A good idea is to exclude unneeded dev files from the final production zip archive file, which is also downloaded by composer (unless --prefer -source is specified).

Those files are only useful when working on the library itself.

If you are not familiar, further information about export-ignore can be found below:

- https://madewithlove.be/gitattributes/
- http://www.pixelite.co.nz/article/using-git-attributes-exclude-files-your-release/

Hope it helps 😊