### PR TITLE
Updated the PHP version to 8.1 (resolved issue with dependencies)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 #   docker build -f Dockerfile-dev -t {{volume_name}} .
 #   docker run -it -p "8080:80" -v $PWD:/var/www {{volume_name}}
 #
-FROM php:8.0-apache
+FROM php:8.1-apache
 
 # system dependecies
 RUN apt-get update \

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "apache"
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "ext-pdo": "*",
         "cakephp/chronos": "^2",


### PR DESCRIPTION
If you try to run "composer install" from the shell with php v.8.0 you receive this error:

Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires monolog/monolog ^3 -> satisfiable by monolog/monolog[3.0.0, ..., 3.3.1].
    - monolog/monolog[3.0.0, ..., 3.3.1] require php >=8.1 -> your php version (8.0.27) does not satisfy that requirement.
  Problem 2
    - symfony/dotenv[v6.1.0, ..., v6.2.5] require php >=8.1 -> your php version (8.0.27) does not satisfy that requirement.
    - Root composer.json requires symfony/dotenv ^6.1 -> satisfiable by symfony/dotenv[v6.1.0, v6.1.11, v6.2.0, v6.2.5].